### PR TITLE
BK-20: fix placeholder logo

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
   <body class="bg-gray-200 flex">
     <nav class="bg-gray-800 text-white w-64 min-h-screen flex flex-col">
       <div class="p-4">
-        <%= image_tag "https://via.placeholder.com/150x50?text=BeliKursus", alt: "logo", class: "w-full" %>
+        <%= image_tag "https://placehold.co/150x50", alt: "logo", class: "w-full" %>
       </div>
 
       <ul class="flex-grow">


### PR DESCRIPTION
Fix the placeholder logo by changed the resource of the logo

after fix:
![CleanShot 2025-01-17 at 19 01 44](https://github.com/user-attachments/assets/5757afb2-8767-443e-859e-d9a4a227e983)
